### PR TITLE
Added hover mode + a few bug fixes and improvements

### DIFF
--- a/src/Config/CustomKeys.cs
+++ b/src/Config/CustomKeys.cs
@@ -42,6 +42,7 @@ namespace VanillaUpgrades
         {
             AddOnKeyDown_World(_main.StopTimewarp, () => TimeManipulation.StopTimewarp(true));
             AddOnKeyDown_World(_main.Throttle01, WorldManager.Throttle01);
+            AddOnKeyDown_World(_main.HoverMode, WorldManager.EnterHoverMode);
             AddOnKeyDown_World(_main.ToggleTorque, VanillaUpgrades.ToggleTorque.Toggle);
         }
 
@@ -60,6 +61,7 @@ namespace VanillaUpgrades
             CreateUI_Text("World");
             CreateUI_Keybinding(StopTimewarp, KeyCode.Slash, "Stop Timewarp");
             CreateUI_Keybinding(Throttle01, KeyCode.C, "Throttle To 0.1%");
+            CreateUI_Keybinding(HoverMode, KeyCode.V, "Hover mode");
             CreateUI_Keybinding(ToggleTorque, KeyCode.T, "Toggle torque");
             CreateUI_Space();
         }
@@ -83,6 +85,8 @@ namespace VanillaUpgrades
         public Key ToggleTorque = KeyCode.T;
 
         public Key Throttle01 = KeyCode.C;
+
+        public Key HoverMode = KeyCode.V;
 
         #endregion
     }

--- a/src/Patches/FlightInfoDrawerPatches.cs
+++ b/src/Patches/FlightInfoDrawerPatches.cs
@@ -1,0 +1,72 @@
+﻿using HarmonyLib;
+using SFS;
+using SFS.Builds;
+using SFS.Parts.Modules;
+using SFS.UI;
+using SFS.World;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine.UI;
+using UnityEngine;
+
+namespace VanillaUpgrades
+{
+    [HarmonyPatch(typeof(FlightInfoDrawer), "Update")]
+    internal static class DisplayAccurateThrustAndLocalTWR
+    {
+        // This method modifies the way thrust and TWR are displayed on the flight information panel:
+        // - Thrust now takes into account engine orientation and stretching - also works with boosters
+        // - TWR is now the local Thrust-To-Weight ratio (takes into account the local gravity)
+        private static void Postfix(ref TextAdapter ___thrustText, ref TextAdapter ___thrustToWeightText)
+        {
+            if (PlayerController.main.player.Value is Rocket rocket)
+            {
+                float mass = rocket.rb2d.mass;
+                float localGravity = (float)(rocket.location.planet.Value.GetGravity(rocket.location.position.Value.magnitude));
+
+                // Calculate thrust, taking into account engines state, stretching and orientation
+                Vector2 thrust = new Vector2(0.0f, 0.0f);
+
+                foreach (EngineModule engineModule in rocket.partHolder.GetModules<EngineModule>())
+                {
+                    if (engineModule.engineOn.Value)
+                    {
+                        Vector2 direction = (Vector2)engineModule.transform.TransformVector(engineModule.thrustNormal.Value);
+
+                        // For cheaters...
+                        float stretchFactor = 1.0f;
+                        if (Base.worldBase.AllowsCheats) stretchFactor = direction.magnitude;
+
+                        Vector2 engineThrust = engineModule.thrust.Value * direction.normalized * stretchFactor * engineModule.throttle_Out.Value;
+                        thrust += engineThrust;
+                    }
+                }
+
+                foreach (BoosterModule boosterModule in rocket.partHolder.GetModules<BoosterModule>())
+                {
+                    if(boosterModule.enabled)
+                    {
+                        Vector2 direction = (Vector2)boosterModule.transform.TransformVector(boosterModule.thrustVector.Value); // equal to thrust * stretch factor in magnitude
+
+                        // For cheaters...
+                        float stretchFactor = 1.0f;
+                        if (Base.worldBase.AllowsCheats) stretchFactor = direction.magnitude / (float)boosterModule.thrustVector.Value.magnitude;
+
+                        // adjusting direction to what it should be now
+                        direction = direction.normalized;
+
+                        thrust += boosterModule.thrustVector.Value.magnitude * direction.normalized * stretchFactor;
+                    }
+                }
+
+                float thrustVal = thrust.magnitude;
+
+                ___thrustText.Text = thrustVal.ToThrustString().Split(':')[1];
+                ___thrustToWeightText.Text = (thrustVal / mass * 9.8f / localGravity).ToTwrString().Split(':')[1];
+            }
+        }
+    }
+}

--- a/src/Patches/WorldPatches.cs
+++ b/src/Patches/WorldPatches.cs
@@ -79,5 +79,48 @@ namespace VanillaUpgrades
 
         }
     }
+
+    [HarmonyPatch(typeof(ThrottleDrawer))]
+    public class ManageHoverMode
+    {
+        [HarmonyPatch("ToggleThrottle")]
+        [HarmonyPostfix]
+        public static void ToggleThrottle_Postfix(ref Throttle_Local ___throttle)
+        {
+            if(!___throttle.Value.throttleOn)
+            {
+                // Do this only if throttle has been turned off (keep hover mode on if this was set before throttle is turned on)
+                WorldManager.ExitHoverMode(true);
+            }
+        }
+
+        [HarmonyPatch("AdjustThrottleRaw")]
+        [HarmonyPostfix]
+        public static void AdjustThrottleRaw_Postfix()
+        {
+            WorldManager.ExitHoverMode(true);
+        }
+
+        [HarmonyPatch("SetThrottleRaw")]
+        [HarmonyPostfix]
+        public static void SetThrottleRaw_Postfix()
+        {
+            WorldManager.ExitHoverMode(true);
+        }
+    }
+
+    [HarmonyPatch(typeof(GameManager))]
+    public class UpdateHoverMode
+    {
+        [HarmonyPatch("Update")]
+        [HarmonyPostfix]
+        public static void Update_Postfix()
+        {
+            if(WorldManager.hoverMode)
+            {
+                WorldManager.TwrTo1();
+            }
+        }
+    }
 }
 

--- a/src/World/WorldManager.cs
+++ b/src/World/WorldManager.cs
@@ -1,17 +1,91 @@
-﻿using SFS.UI;
+﻿using SFS;
+using SFS.Parts.Modules;
+using SFS.UI;
 using SFS.World;
+using UnityEngine;
 
 namespace VanillaUpgrades
 {
     internal static class WorldManager
     {
         public static Rocket currentRocket;
-        
+
+        public static bool hoverMode = false;
 
         public static void Throttle01()
         {
             if (currentRocket == null || !PlayerController.main.HasControl(MsgDrawer.main)) return;
+            if (!SFS.World.WorldTime.main.realtimePhysics.Value)
+            {
+                MsgDrawer.main.Log("Cannot throttle while timewarping");
+                return;
+            }
+            ExitHoverMode(true);
             currentRocket.throttle.throttlePercent.Value = 0.0005f;
+        }
+
+        public static void EnterHoverMode()
+        {
+            if (!SFS.World.WorldTime.main.realtimePhysics.Value)
+            {
+                MsgDrawer.main.Log("Cannot hover while timewarping");
+            }
+            else
+            {
+                MsgDrawer.main.Log("Hover mode active");
+                hoverMode = true;
+                TwrTo1();
+            }
+        }
+
+        public static void ExitHoverMode(bool showMsg)
+        {
+            if(hoverMode && showMsg) MsgDrawer.main.Log("Exit hover mode");
+            hoverMode = false;
+        }
+
+        public static void TwrTo1()
+        {
+            if (currentRocket == null || !PlayerController.main.HasControl(MsgDrawer.main))
+            {
+                ExitHoverMode(false);
+                return;
+            }
+
+            float mass = currentRocket.rb2d.mass;
+            float localGravity = (float)(currentRocket.location.planet.Value.GetGravity(currentRocket.location.position.Value.magnitude));
+
+            // Calculate thrust at 100% throttle (this method takes into account each engine's direction)
+            // Note: Boosters are ignored. But honestly you wouldn't use that functionality with boosters...
+            Vector2 thrustAt100PerCent = new Vector2(0.0f, 0.0f);
+
+            foreach (EngineModule engineModule in currentRocket.partHolder.GetModules<EngineModule>())
+            {
+                if(engineModule.engineOn.Value) // engine has to be on
+                {
+                    Vector2 direction = (Vector2)engineModule.transform.TransformVector(engineModule.thrustNormal.Value);
+
+                    // For cheaters...
+                    float stretchFactor = 1.0f;
+                    if (Base.worldBase.AllowsCheats) stretchFactor = direction.magnitude;
+
+                    Vector2 engineThrust = engineModule.thrust.Value * direction.normalized * stretchFactor;
+                    thrustAt100PerCent += engineThrust;
+                }
+            }
+
+            float TwrAt100PerCent = thrustAt100PerCent.magnitude / mass * 9.8f / localGravity;
+
+            if(TwrAt100PerCent < 1.0)
+            {
+                // Throttle at 100% is not enough to reach TWR of 1 -> set it at 100% (Note: also works if thrust is 0)
+                currentRocket.throttle.throttlePercent.Value = 1.0f;
+            }
+            else
+            {
+                // Adjust the throttle at the suited value
+                currentRocket.throttle.throttlePercent.Value = 1.0f / TwrAt100PerCent;
+            }
         }
 
         private static void UpdatePlayer()
@@ -20,6 +94,7 @@ namespace VanillaUpgrades
                 ? PlayerController.main.player.Value as Rocket
                 : null;
             ToggleTorque.disableTorque = false;
+            ExitHoverMode(false);
         }
 
         public static void Setup()


### PR DESCRIPTION
#### Flight information panel improvements
- Thrust now takes into account angled engines and stretch factor
- Thrust/Weight is based on actual thrust (mentionned above) and on the current local gravity (gravity was always assumed to be Earth's gravity before)

#### Hover mode
Pressing V will activate hover mode: the throttle is automatically adjusted so that the TWR is exactly 1.0, so that thrust cancels gravity. While in hover mode, the throttle is dynamically adjusted to take into account the fuel loss without needing any action from the player. Hover mode is automatically interrupted as soon as the player adjusts the throttle himself with the usual commands.

#### Bug fix
- "Throttle to 0.1%" can no longer be activated in time-warp mode